### PR TITLE
Update dependency grunt-contrib-jshint to ^0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "grunt-contrib-cssmin": "^0.9.0",
     "grunt-contrib-htmlmin": "^0.3.0",
     "grunt-contrib-imagemin": "^0.8.1",
-    "grunt-contrib-jshint": "^0.10.0",
+    "grunt-contrib-jshint": "^0.12.0",
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-filerev": "^0.2.1",


### PR DESCRIPTION
This Pull Request updates dependency [grunt-contrib-jshint](https://github.com/gruntjs/grunt-contrib-jshint) from `^0.10.0` to `^0.12.0`




<details>
<summary>Commits</summary>

#### v0.11.0
-   [`1c973c3`](https://github.com/gruntjs/grunt-contrib-jshint/commit/1c973c3b93ace54a223eaf27ac16430635d18698) Add Windows CI
-   [`977dbd2`](https://github.com/gruntjs/grunt-contrib-jshint/commit/977dbd2a249b06a6fb6097c757354710d672171e) Update .travis.yml
-   [`1a4f486`](https://github.com/gruntjs/grunt-contrib-jshint/commit/1a4f4864681e940cbc28cebf36e012b88a240575) Add test for rule codes. Issue #&#8203;156.
-   [`eb5014d`](https://github.com/gruntjs/grunt-contrib-jshint/commit/eb5014df40f8d26265ee49aa7694d1dbf4f98729) Update .travis.yml
-   [`7719f30`](https://github.com/gruntjs/grunt-contrib-jshint/commit/7719f30d218e2d81c723d6d791052d9922bf0f1f) Update jshint.js
-   [`7919597`](https://github.com/gruntjs/grunt-contrib-jshint/commit/79195977468d05fd83a5a1c169ba7a494b142366) Merge pull request #&#8203;182 from sudodoki/patch-1
-   [`c8a7ad7`](https://github.com/gruntjs/grunt-contrib-jshint/commit/c8a7ad777daaa761b4cceec2f30f23f5574634db) update appveyor config
-   [`cfb7130`](https://github.com/gruntjs/grunt-contrib-jshint/commit/cfb713028535b9c4acd73e33480e479fb7256c7e) Update copyright to 2015
-   [`6fc405f`](https://github.com/gruntjs/grunt-contrib-jshint/commit/6fc405f50c06f2d4fd5e21e945f77445c8803011) Update dependencies including JSHint 2.6.0.
-   [`7eadae5`](https://github.com/gruntjs/grunt-contrib-jshint/commit/7eadae5322f0943a58dd1783ea3745e86f1874ba) Merge pull request #&#8203;190 from XhmikosR/master
-   [`9469e62`](https://github.com/gruntjs/grunt-contrib-jshint/commit/9469e62d05ec6e69fe97fe430b295c230990bc51) Update appveyor.yml.
-   [`5d8c44f`](https://github.com/gruntjs/grunt-contrib-jshint/commit/5d8c44fbb2333f62e21f0658de4a572d889a8c62) Merge pull request #&#8203;191 from XhmikosR/master
-   [`a3d1a5b`](https://github.com/gruntjs/grunt-contrib-jshint/commit/a3d1a5b6240e8b77ca6d3b20d2ff77bdb83b2253) v0.11.0
#### v0.11.1
-   [`b402e58`](https://github.com/gruntjs/grunt-contrib-jshint/commit/b402e588b573febc1fbba37c9716ef398ce02964) Update .travis.yml
-   [`558cbe3`](https://github.com/gruntjs/grunt-contrib-jshint/commit/558cbe372f444c05acb02479bdb335487819905a) package.json tweaks
-   [`864ad1c`](https://github.com/gruntjs/grunt-contrib-jshint/commit/864ad1c6cfd95d9480c955b1fb08c092c14d450a) Update appveyor.yml.
-   [`eb260e7`](https://github.com/gruntjs/grunt-contrib-jshint/commit/eb260e76043741ed5fefb79aa80b71194115cb7a) Update JSHint&#x27;s options.
-   [`8172541`](https://github.com/gruntjs/grunt-contrib-jshint/commit/8172541b20e692356f2d04a132ea1029677626ea) Update appveyor.yml.
-   [`21cdd51`](https://github.com/gruntjs/grunt-contrib-jshint/commit/21cdd51a98786520c17a9aa097ac7abe92e37de2) Update appveyor.yml.
-   [`b10b00b`](https://github.com/gruntjs/grunt-contrib-jshint/commit/b10b00be91922e4b4baf4c3edcffcdab4c613c10) ensure options to path.resolve are strings
-   [`5560ba9`](https://github.com/gruntjs/grunt-contrib-jshint/commit/5560ba9156f207b760379f5d2d1b63ca1752ef10) Merge pull request #&#8203;195 from jasonkarns/patch-1
-   [`f8b57aa`](https://github.com/gruntjs/grunt-contrib-jshint/commit/f8b57aa5adcaf2da723c361ab3defbf5d7f636ac) fixes jshint errors
-   [`07db678`](https://github.com/gruntjs/grunt-contrib-jshint/commit/07db6788d422b847f5eb87bbe7c858ed6158b515) add extra tests for .jshintignore
-   [`a0cd3db`](https://github.com/gruntjs/grunt-contrib-jshint/commit/a0cd3db0638ad860e562e7e12bfff734aa04ac9f) Don’t force reporterOutput to null
-   [`e7aa6c4`](https://github.com/gruntjs/grunt-contrib-jshint/commit/e7aa6c4902d70d2257b6bf094a80d5d7ec15cae3) Merge pull request #&#8203;197 from scottnonnenberg/fix-io-1.6.0
-   [`040ab80`](https://github.com/gruntjs/grunt-contrib-jshint/commit/040ab8009ec1108744dfd14b0f3abd882d0854c6) v0.11.1
#### v0.11.2
-   [`1c0bc91`](https://github.com/gruntjs/grunt-contrib-jshint/commit/1c0bc9131fee20cccc317d440ae88140ad3a50e2) Close #&#8203;199 PR: fix default value of option reporter.
-   [`7b32f37`](https://github.com/gruntjs/grunt-contrib-jshint/commit/7b32f3700e0eb8e894d18d77cd06cfe616c8fcec) changelog
-   [`56713d4`](https://github.com/gruntjs/grunt-contrib-jshint/commit/56713d4b3f223d24c82edab7c8b5729b73e5d848) 0.11.2
#### v0.11.3
-   [`691935c`](https://github.com/gruntjs/grunt-contrib-jshint/commit/691935cdedd58094f13949c59b790a11a33c5175) Lint fixes.
-   [`e59e1ea`](https://github.com/gruntjs/grunt-contrib-jshint/commit/e59e1ea47d492f7fccdbc4a0b9d858248b18a1c7) Update appveyor.yml.
-   [`57e9aab`](https://github.com/gruntjs/grunt-contrib-jshint/commit/57e9aabefa0d3e0ee0ff149bd489117292ee993b) Update license attribute
-   [`edf46ca`](https://github.com/gruntjs/grunt-contrib-jshint/commit/edf46ca03971b48da5a5df3d152ddddff255e423) Merge pull request #&#8203;204 from pdehaan/patch-1
-   [`506dc54`](https://github.com/gruntjs/grunt-contrib-jshint/commit/506dc544715050e1999cbbfb30ca4873978e8ce3) make relative reporterOutput paths optional
-   [`186afd6`](https://github.com/gruntjs/grunt-contrib-jshint/commit/186afd6309c3d7c51dbfd8900e3e204ff5cb17d9) Update to JSHint 2.8.0
-   [`4af02ee`](https://github.com/gruntjs/grunt-contrib-jshint/commit/4af02eec6df7cd1e8a8e8f939a302a5135cc9cca) Prepare changelog for next release
-   [`7c6975a`](https://github.com/gruntjs/grunt-contrib-jshint/commit/7c6975a2ecfa7025e01edac5e9bd9ad0103478f6) Merge pull request #&#8203;215 from Tiross/develop
-   [`7304348`](https://github.com/gruntjs/grunt-contrib-jshint/commit/730434875b15d79970b736aadac246cfc400bfe4) v0.11.3
#### v0.12.0
-   [`aa19a8d`](https://github.com/gruntjs/grunt-contrib-jshint/commit/aa19a8dc53124d66ec1be4ba54c9ab1fd8d423b7) CI: test node.js 4.0.
-   [`810c393`](https://github.com/gruntjs/grunt-contrib-jshint/commit/810c393c7837621ee8f0d8a8abe4b83640bffa67) Fix typos in docs.
-   [`547cf4b`](https://github.com/gruntjs/grunt-contrib-jshint/commit/547cf4b8bfa90e64345b735f9ca7ddcdc057ecbf) Update appveyor.yml.
-   [`789f405`](https://github.com/gruntjs/grunt-contrib-jshint/commit/789f4055aa2c0c1d3fda31044f4f052a0f217925) Fix typo&#x27;s typo.
-   [`d4f5023`](https://github.com/gruntjs/grunt-contrib-jshint/commit/d4f5023ba54700cd67fe3fd8174046bddb9102ce) Update CHANGELOG.
-   [`efbb6f6`](https://github.com/gruntjs/grunt-contrib-jshint/commit/efbb6f6f0f2b93ec83e1cc5024a26c08b7977702) formatting
-   [`6df2d10`](https://github.com/gruntjs/grunt-contrib-jshint/commit/6df2d100fad30a528951a7d7886eb0003df2d2d1) CI: Remove node.js &#x27;0.12&#x27; and add &#x27;5&#x27;.
-   [`333d69f`](https://github.com/gruntjs/grunt-contrib-jshint/commit/333d69f358b143b60f206b1e2da9a3e1de3625c4) Update copyright to 2016
-   [`3a23c20`](https://github.com/gruntjs/grunt-contrib-jshint/commit/3a23c20719efb361498ffe8b59d6bd3669d1f5c2) Bump JSHint to v2.9.1.
-   [`cd26571`](https://github.com/gruntjs/grunt-contrib-jshint/commit/cd2657120ff93c65988490210e8fb0d19ab75138) v0.12.0

</details>