### PR TITLE
Update dependency grunt-ng-annotate to ^0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "grunt-google-cdn": "^0.4.0",
     "grunt-karma": "^0.9.0",
     "grunt-newer": "^0.7.0",
-    "grunt-ng-annotate": "^0.4.0",
+    "grunt-ng-annotate": "^0.10.0",
     "grunt-svgmin": "^0.4.0",
     "grunt-usemin": "^2.1.1",
     "grunt-wiredep": "^1.7.0",


### PR DESCRIPTION
This Pull Request updates dependency [grunt-ng-annotate](https://github.com/mgol/grunt-ng-annotate) from `^0.4.0` to `^0.10.0`



<details>
<summary>Release Notes</summary>

### [`v0.5.0`](https://github.com/mgol/grunt-ng-annotate/releases/0.5.0)

Update ng-annotate to `~0.11.0` (#&#8203;17).

---

### [`v0.6.0`](https://github.com/mgol/grunt-ng-annotate/releases/0.6.0)

1. Update ng-annotate to `~0.12.0`.
2. Add more keywords.

---

### [`v0.7.0`](https://github.com/mgol/grunt-ng-annotate/releases/0.7.0)

Update ng-annotate to `~0.13.0`.

---

### [`v0.8.0`](https://github.com/mgol/grunt-ng-annotate/releases/0.8.0)

Update ng-annotate to `~0.14.0`.

---

### [`v0.9.0`](https://github.com/mgol/grunt-ng-annotate/releases/0.9.0)

1. Remove the `main` field from `package.json`.
2. Remove deprecated `outputFileSuffix` & `transformDest` options; print errors if used.
3. Update ng-annotate to `~0.15.1` (includes io.js fixes and a default ES6 mode).
4. Initial support for source maps (#&#8203;18).
5. Insert a semi-colon between concatenated files (#&#8203;22).

---

### [`v0.9.1`](https://github.com/mgol/grunt-ng-annotate/releases/0.9.1)

Hotfix: move lodash from devDependencies to dependencies (#&#8203;23)

---

### [`v0.9.2`](https://github.com/mgol/grunt-ng-annotate/releases/0.9.2)

1. Use "/" as path delimiter in sourceMappingURL even on Windows
2. Fix Windows build issues.

---

### [`v0.10.0`](https://github.com/mgol/grunt-ng-annotate/releases/0.10.0)

1. Officially support Node.js 0.12 & io.js in addition to Node.js 0.10
2. Add a separator option; don't use `;` by default.
3. More test coverage.

---

</details>


<details>
<summary>Commits</summary>

#### v0.9.0
-   [`e9745b8`](https://github.com/mgol/grunt-ng-annotate/commit/e9745b8477c80759dd2b375c0188557d77f6122c) Remove the main field from package.json
-   [`5565e1a`](https://github.com/mgol/grunt-ng-annotate/commit/5565e1a6f0858fa7e96eed4ef06bc30b90c3a4c4) AppVeyor: Break an exceptionally long line into smaller ones
-   [`953adf8`](https://github.com/mgol/grunt-ng-annotate/commit/953adf8224afa5ec65e05f94121ec045770eb126) Travis: add sudo: false to speed up the build
-   [`cd5a4f5`](https://github.com/mgol/grunt-ng-annotate/commit/cd5a4f54d45b19af91996362065247de93e11f92) AppVeyor: speed up Node installation
-   [`35065a4`](https://github.com/mgol/grunt-ng-annotate/commit/35065a41e0f47f90b50ba864d0012e43888d5483) Travis/AppVeyor: don&#x27;t disable the spinner; it&#x27;s already disabled
-   [`5ab0cff`](https://github.com/mgol/grunt-ng-annotate/commit/5ab0cff5a7b817d0519a95d0b5f20a382b7c23bd) AppVeyor: switch the badge to SVG
-   [`0ff2951`](https://github.com/mgol/grunt-ng-annotate/commit/0ff29518b6530d1bf993bd028686e9e0b809726f) package.json: change licenses to license
-   [`836a4f1`](https://github.com/mgol/grunt-ng-annotate/commit/836a4f1954a54e930b983ded8db1178983a3054f) Update npm deps
-   [`3d4e3ea`](https://github.com/mgol/grunt-ng-annotate/commit/3d4e3eae5746d0fafcf1422b6771f011d6697234) Bump to 0.9.0-pre
-   [`a7767eb`](https://github.com/mgol/grunt-ng-annotate/commit/a7767ebdb974072741c32d05f825a9e94f8d9184) Remove deprecated options: transformDest &amp; outputFileSuffix
-   [`d447fd8`](https://github.com/mgol/grunt-ng-annotate/commit/d447fd850487b224a3c06bb81473bd8103e5d0e1) Bump npm deps (includong ng-annotate from ~0.14.0 to ~0.15.1)
-   [`8ad9914`](https://github.com/mgol/grunt-ng-annotate/commit/8ad9914df1364a2c1fd588a7f3d9dfb543ce18ef) Insert a semicolon between concatenated files
-   [`52ee361`](https://github.com/mgol/grunt-ng-annotate/commit/52ee36191b3e9b00a6b634c447b186ee214f7f46) README: refactor options description
-   [`06e8800`](https://github.com/mgol/grunt-ng-annotate/commit/06e88008d045cf4fc27ff236825ec07c20f60b9c) Add source map support
-   [`3f5a78f`](https://github.com/mgol/grunt-ng-annotate/commit/3f5a78f65cf4ec0805ca1648b5b3a83ed70257a9) Tag 0.9.0
-   [`3d4e267`](https://github.com/mgol/grunt-ng-annotate/commit/3d4e2678614cb58b6e9588daa6c24db01848144e) Bump to 0.9.1-pre
#### v0.9.1
-   [`d753dad`](https://github.com/mgol/grunt-ng-annotate/commit/d753dadd11529269800577755a7eb913fa4dc723) Hotfix: lodash is a dependency, not a dev dependency
-   [`1ebd338`](https://github.com/mgol/grunt-ng-annotate/commit/1ebd33800872d66eff5a5b8afe024d9739919412) Tag 0.9.1
-   [`42214a6`](https://github.com/mgol/grunt-ng-annotate/commit/42214a6832f16dfc8259fd32bb54c3a0e45cc8fb) Bump to 0.9.2-pre
#### v0.9.2
-   [`dec2dd8`](https://github.com/mgol/grunt-ng-annotate/commit/dec2dd846787d367fcba6d9bd6c1b3a579c781d4) Use &quot;/&quot; as path delimiter in sourceMappingURL even on Windows
-   [`e71afd4`](https://github.com/mgol/grunt-ng-annotate/commit/e71afd44445f13b521f51781f1afc98c61cc7596) Tag 0.9.2
-   [`717b43c`](https://github.com/mgol/grunt-ng-annotate/commit/717b43c83c106369dd8a85f1a12f3c242e3211cc) Bump to 0.9.3-pre
#### v0.10.0
-   [`f3fba95`](https://github.com/mgol/grunt-ng-annotate/commit/f3fba952bd609a89ecaf016cdde3d8da0e402af2) AppVeyor: test on io.js
-   [`54dcd13`](https://github.com/mgol/grunt-ng-annotate/commit/54dcd13d2392f2f1b7f721efe9fb9cecf0fb13b7) AppVeyor: update npm on io.js 1.0.3, the built-in one is broken
-   [`e9c169f`](https://github.com/mgol/grunt-ng-annotate/commit/e9c169f375f2876a653627c99205d49c1f4b564e) AppVeyor: fix the npm update commands
-   [`3004570`](https://github.com/mgol/grunt-ng-annotate/commit/30045707bcbe8026d0d667f29193d8d7b1b6fc74) AppVeyor: fix the PATH changing command
-   [`ad6033b`](https://github.com/mgol/grunt-ng-annotate/commit/ad6033bc7f8bfff5b24f17d777c8499b0e7e61a4) AppVeyor: blacklist io.js for now (until 1.0.4 arrives)
-   [`520617a`](https://github.com/mgol/grunt-ng-annotate/commit/520617a3b81ba86615e331fa1e3f0163eb482060) AppVeyor: instead of blacklisting io.js 1.0.3, update it to 1.0.4
-   [`ae6bc77`](https://github.com/mgol/grunt-ng-annotate/commit/ae6bc7783c5bb538ba15ab139fb226adbdb376e1) AppVeyor: typo fix
-   [`f482d27`](https://github.com/mgol/grunt-ng-annotate/commit/f482d275d7d92bcf90e307760b5e8fcdf207c634) AppVeyor: allow failures on io.js 1.0 for now (again)
-   [`244355b`](https://github.com/mgol/grunt-ng-annotate/commit/244355b21f4aa518883866279f8d48cdde04fb48) AppVeyor: next attempt at updating io.js to 1.0.4
-   [`97e7be2`](https://github.com/mgol/grunt-ng-annotate/commit/97e7be2c0ae0e7894ec64e4f53ccdd31c2dfcf17) AppVeyor: don&#x27;t treat io.js in a special way any more; don&#x27;t allow failures
-   [`f525e4a`](https://github.com/mgol/grunt-ng-annotate/commit/f525e4afdbec2dd9b3568b05695c481e2a01873d) Update npm deps
-   [`907078d`](https://github.com/mgol/grunt-ng-annotate/commit/907078dadbc8ca16d3b822dc7dabba129d15a655) AppVeyor: test on io.js 1.*.*, not 1.0.*
-   [`47eec29`](https://github.com/mgol/grunt-ng-annotate/commit/47eec29626de7b04b33cb93abb2c70df0d542334) Require grunt ~0.4.5
-   [`9368e28`](https://github.com/mgol/grunt-ng-annotate/commit/9368e287d992e0ef7ae333a5f60483d89c20dedc) Switch from lodash to lodash.clonedeep
-   [`0b25e14`](https://github.com/mgol/grunt-ng-annotate/commit/0b25e14a81aee3b001eb31cdc217c3907030d8ae) Travis: test on io.js
-   [`6373718`](https://github.com/mgol/grunt-ng-annotate/commit/6373718e14e7b55059774129c94b3697d6b2a09c) Travis: test on Node.js 0.12 instead of 0.11
-   [`98b2ed6`](https://github.com/mgol/grunt-ng-annotate/commit/98b2ed625e77e3e0240e5408f076cc142c3243f6) AppVeyor: test on Node.js 0.12 instead of 0.11
-   [`c2cf408`](https://github.com/mgol/grunt-ng-annotate/commit/c2cf408d3fb49f93e7eb065910fbb1ba199efefd) feat: add a separator option; don&#x27;t use `;` by default.
-   [`d6e2684`](https://github.com/mgol/grunt-ng-annotate/commit/d6e2684111d018d0f6f7f07848ad8a35c51f65e1) Add a test ensuring overwriting files works
-   [`5c53492`](https://github.com/mgol/grunt-ng-annotate/commit/5c534926bf109e8b9134d04c48a1d20367d1e6f2) Include grunt as a devDependency as well
-   [`c65413e`](https://github.com/mgol/grunt-ng-annotate/commit/c65413e4ba56e241adc1c4b584ea26503e21d6ac) Update deps
-   [`2327edf`](https://github.com/mgol/grunt-ng-annotate/commit/2327edfa5929023a20ca19c2a28aabc91deeb4d2) Tag 0.10.0
-   [`88d9c3f`](https://github.com/mgol/grunt-ng-annotate/commit/88d9c3fd27822ef0b88cd37cbe9f2bab6697abab) Bump to 0.10.1-pre

</details>