### PR TITLE
Update dependency jshint-stylish to ^0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-usemin": "^2.1.1",
     "grunt-wiredep": "^1.7.0",
     "jasmine-core": "^2.1.2",
-    "jshint-stylish": "^0.2.0",
+    "jshint-stylish": "^0.4.0",
     "karma": "^0.12.25",
     "karma-jasmine": "^0.3.0",
     "karma-phantomjs-launcher": "^0.1.4",


### PR DESCRIPTION
This Pull Request updates dependency [jshint-stylish](https://github.com/sindresorhus/jshint-stylish) from `^0.2.0` to `^0.4.0`




<details>
<summary>Commits</summary>

#### v0.3.0
-   [`bd1ab89`](https://github.com/sindresorhus/jshint-stylish/commit/bd1ab89c0d083cf1b0b7ad3303676e233dd5daaf) don&#x27;t use bold
-   [`551dfc4`](https://github.com/sindresorhus/jshint-stylish/commit/551dfc49d719146120b93ed4c7728d34bb6b201b) 0.2.0
-   [`e4b853a`](https://github.com/sindresorhus/jshint-stylish/commit/e4b853aeb5672420403b51240bcfdf0d989589e7) Close GH-15: improves visibility on windows.
#### v0.4.0
-   [`c678bc1`](https://github.com/sindresorhus/jshint-stylish/commit/c678bc1a52bc542653119efd29d5e4e94f5ab2ea) 0.3.0
-   [`9e4769c`](https://github.com/sindresorhus/jshint-stylish/commit/9e4769c7ea9d19fb623a3a0139560fa6d832f278) Update .travis.yml

</details>