### PR TITLE
Update dependency load-grunt-tasks to ^0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "karma": "^0.12.25",
     "karma-jasmine": "^0.3.0",
     "karma-phantomjs-launcher": "^0.1.4",
-    "load-grunt-tasks": "^0.4.0",
+    "load-grunt-tasks": "^0.6.0",
     "time-grunt": "^0.3.1"
   },
   "engines": {


### PR DESCRIPTION
This Pull Request updates dependency [load-grunt-tasks](https://github.com/sindresorhus/load-grunt-tasks) from `^0.4.0` to `^0.6.0`




<details>
<summary>Commits</summary>

#### v0.5.0
-   [`be3135b`](https://github.com/sindresorhus/load-grunt-tasks/commit/be3135bcdab01c3c15a0d91b6d4c3eaf55d6f531) Update .travis.yml
-   [`cb82cc7`](https://github.com/sindresorhus/load-grunt-tasks/commit/cb82cc7555ad9d9dc8737b19e8d401f6112f8bcc) Update readme.md
-   [`1aa6404`](https://github.com/sindresorhus/load-grunt-tasks/commit/1aa6404eaa48a26151558eb07c9384c02ab68a90) Update readme.md
-   [`3d33734`](https://github.com/sindresorhus/load-grunt-tasks/commit/3d337346714b15e6500c2736c9e5ecbf3a139225) bump multimatch
#### v0.6.0
-   [`52bce00`](https://github.com/sindresorhus/load-grunt-tasks/commit/52bce0074732acc5e8753ee16a051e77e7928b6e) 0.5.0

</details>