### PR TITLE
Update dependency time-grunt to ^0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "karma-jasmine": "^0.3.0",
     "karma-phantomjs-launcher": "^0.1.4",
     "load-grunt-tasks": "^0.4.0",
-    "time-grunt": "^0.3.1"
+    "time-grunt": "^0.4.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
This Pull Request updates dependency [time-grunt](https://github.com/sindresorhus/time-grunt) from `^0.3.1` to `^0.4.0`




<details>
<summary>Commits</summary>

#### v0.4.0
-   [`cc2e575`](https://github.com/sindresorhus/time-grunt/commit/cc2e5756eb0f522e657e249488380c5546a59416) Close GH-44: Allow `--verbose` and `-v` as options that display the graphs..
-   [`1dd003d`](https://github.com/sindresorhus/time-grunt/commit/1dd003d1373b66414ae7b63b1c347ef26c89922f) 0.3.2
-   [`e532c4e`](https://github.com/sindresorhus/time-grunt/commit/e532c4e056b6d90a0a5a9e1b9dfe9b8a2935422e) semicolon
-   [`c23982b`](https://github.com/sindresorhus/time-grunt/commit/c23982bd9c1744a10d2ee9b057d1a39d4d2b078d) bump deps and use figures module

</details>