### PR TITLE
Update dependency grunt to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "dependencies": {},
   "devDependencies": {
-    "grunt": "^0.4.1",
+    "grunt": "^1.0.0",
     "grunt-autoprefixer": "^0.7.3",
     "grunt-concurrent": "^0.5.0",
     "grunt-contrib-clean": "^0.5.0",


### PR DESCRIPTION
This Pull Request updates dependency [grunt](https://github.com/gruntjs/grunt) from `^0.4.1` to `^1.0.0`




<details>
<summary>Commits</summary>

#### v1.0.0
-   [`265a868`](https://github.com/gruntjs/grunt/commit/265a86873bb126ee37eb51f48b4e27cc26ef50c3) Merge pull request #&#8203;1443 from dmethvin/1442-test-admin
-   [`d21272a`](https://github.com/gruntjs/grunt/commit/d21272a16c72ab2f1f4add1e3ea4d2121998bd93) Prevent async callback from being called multiple times
-   [`448f54e`](https://github.com/gruntjs/grunt/commit/448f54ef25c17bf520eb39ff6bef28b2d1a0c0d3) Merge pull request #&#8203;1464 from notclive/master
-   [`7e2c065`](https://github.com/gruntjs/grunt/commit/7e2c0653604f5d39a1eb89fc97f01144589a9ee5) Update copyright to jQuery Foundation and remove redundant headers
-   [`a8abb9a`](https://github.com/gruntjs/grunt/commit/a8abb9aab6791c02e13183016003d2fd09c73913) Merge pull request #&#8203;1480 from dmethvin/1478-license
-   [`e7f52b9`](https://github.com/gruntjs/grunt/commit/e7f52b9391048ab866e77bd57b76f9ae879fabfb) Update glob to 7.0.x. Fixes GH-1467
-   [`952fe14`](https://github.com/gruntjs/grunt/commit/952fe14bc2d442b0c88c2a86854e2e8e153ef151) Removing BOM strip code that duplicates iconv.decode() handling.
-   [`5921eb3`](https://github.com/gruntjs/grunt/commit/5921eb3116d29fab6baf31a4e4d3e80e5ef62b79) Update 3 packages
-   [`43a7b26`](https://github.com/gruntjs/grunt/commit/43a7b26d9bab2b2fc214bc2b0c83026a93e00c8e) Adding 1.0.0 changelog, bumping version
-   [`e2703ad`](https://github.com/gruntjs/grunt/commit/e2703ada251509088ab7f3323f9e9475b7fba585) Merge pull request #&#8203;1489 from paladox/patch-10
-   [`c807e79`](https://github.com/gruntjs/grunt/commit/c807e791ccb60a7df07d80966d00cbc9ca5e84bd) Merge pull request #&#8203;1481 from arithmetric/feature/update_glob
-   [`f95c594`](https://github.com/gruntjs/grunt/commit/f95c594825d0254b8523fc5e7a4c5977263b10f9) Merge pull request #&#8203;1482 from arithmetric/feature/remove_duplicate_BOM_handling
-   [`93c6e13`](https://github.com/gruntjs/grunt/commit/93c6e131d9de31099683930b43ed03dd536a58dc) Merge pull request #&#8203;1485 from gruntjs/rc2
-   [`f0c2a9f`](https://github.com/gruntjs/grunt/commit/f0c2a9f07516ab97451709612fffc0ddca726adc) Ensure a grunt bin gets created upon install
-   [`0b6c38f`](https://github.com/gruntjs/grunt/commit/0b6c38fc21f9ccfd8619d95e54a94ccdb261f496) Merge pull request #&#8203;1493 from gruntjs/fix-cli-bin
-   [`491344a`](https://github.com/gruntjs/grunt/commit/491344aa8dc62e21066bbdbab2f18f1f8a0e8beb) Use grunt-known-options for shared options between Grunt and grunt-cli
-   [`353fd1c`](https://github.com/gruntjs/grunt/commit/353fd1c6793e1cc0e7793666497db3b77f71cab4) Update known options to 1.1.0 which includes b for base short option
-   [`bc5bc7c`](https://github.com/gruntjs/grunt/commit/bc5bc7ca13ecf69257a86c0f9a042977c38692f7) Merge pull request #&#8203;1495 from gruntjs/grunt-known-options
-   [`475ea37`](https://github.com/gruntjs/grunt/commit/475ea37bb2c078a1c436ac210c3b6e5670037181) update to latest cli ~1.2.0
-   [`84bdbf1`](https://github.com/gruntjs/grunt/commit/84bdbf1e0304f333c1e836e12a2bb48035cdf905) Merge pull request #&#8203;1494 from gruntjs/cli110
-   [`71d7504`](https://github.com/gruntjs/grunt/commit/71d7504a2479f6fd05733a0be870dbcd013bdb8b) update legacy log and util to 1.0.0
-   [`49c9737`](https://github.com/gruntjs/grunt/commit/49c9737e99fcd6e3a4ea5cd38af3751ef6ea70cd) Merge pull request #&#8203;1498 from gruntjs/update-util-log
-   [`26c6c3c`](https://github.com/gruntjs/grunt/commit/26c6c3c80ce9db13e0c8d83bceff48c5c87b3bb7) update 1.0.0 changelog
#### v1.0.1
-   [`416859c`](https://github.com/gruntjs/grunt/commit/416859c362814d152dc90cc74299c6e494b93849) Use local bin that points to grunt-cli
-   [`6b60a41`](https://github.com/gruntjs/grunt/commit/6b60a412a58392cbb4ad362156c582d1891139a2) Include bin in the package.json files
-   [`d097191`](https://github.com/gruntjs/grunt/commit/d09719129ca620e3be32775c3492c2912528b070) Merge pull request #&#8203;1500 from gruntjs/fixbin
-   [`ac9de12`](https://github.com/gruntjs/grunt/commit/ac9de1240b7aa286995742e2424aa2138a521c11) add 1.0.1 changelog
-   [`8ada494`](https://github.com/gruntjs/grunt/commit/8ada4948b69c6ec9b1e956b5e6b2e6814fa054ca) Merge pull request #&#8203;1502 from gruntjs/101-cli-fix
#### v1.0.2
-   [`3484b83`](https://github.com/gruntjs/grunt/commit/3484b83a87e1f5ea689aa5aece9f9ae96151d3ff) Fix for readYAML error messages
-   [`add5279`](https://github.com/gruntjs/grunt/commit/add52798397ff2a3e4a956ee96e81cd42104dda0) Add error.yaml fixture for readYAML test
-   [`afbda70`](https://github.com/gruntjs/grunt/commit/afbda709aac89aa5b375324b525622e57c812e11) test node.js 6 on travis
-   [`29c506c`](https://github.com/gruntjs/grunt/commit/29c506cb05727008d8af5f6f73fe5c0908af8570) Merge pull request #&#8203;1510 from gruntjs/node6-travis
-   [`f152402`](https://github.com/gruntjs/grunt/commit/f1524025c1e432f35025986ac3efbb29a054bbc6) Merge pull request #&#8203;1534 from markelog/eslint r&#x3D;vladikoff,shama
-   [`87f82fb`](https://github.com/gruntjs/grunt/commit/87f82fb92a3d61866a796e7df2adb19da68d87a8) lock eslint versions for consistency (#&#8203;1535)
-   [`a09f84c`](https://github.com/gruntjs/grunt/commit/a09f84c8aedfc87cbf357b1ac45b7b70571e954f) update minimatch dependency to avoid security alerts (#&#8203;1536)
-   [`cef9f8c`](https://github.com/gruntjs/grunt/commit/cef9f8cf4a01e5e49d3f6d3a6642db2500e72b1e) Change repository field in package.json
-   [`6c596b1`](https://github.com/gruntjs/grunt/commit/6c596b186dcd382750fc7d6ccf9f749d8fd06287) Merge pull request #&#8203;1577 from omytryniuk/gruntpackage.json-error
-   [`82ebdc8`](https://github.com/gruntjs/grunt/commit/82ebdc85b504f2efc1ac9826f0aa4d18a1bc69fe) Add license report and scan badge (#&#8203;1586) r&#x3D;vladikoff
-   [`115a182`](https://github.com/gruntjs/grunt/commit/115a18234d2ca40163761e76384101da0dfe5991) Update License section in README
-   [`5655676`](https://github.com/gruntjs/grunt/commit/5655676a6f11820e802d0f31e3efa8f54a05f0dd) Add Node.js v7 and v8 to Travis CI
-   [`b63aeec`](https://github.com/gruntjs/grunt/commit/b63aeecf1be86e4811f6096b41ec21c2b6a0f0d5) Dont manually install npm, use the version each node version corresponds with
-   [`6592ad1`](https://github.com/gruntjs/grunt/commit/6592ad18d81612a55574743fd0fd828e5227d82a) Update travis/appveyor to node versions we support
-   [`400601a`](https://github.com/gruntjs/grunt/commit/400601a6aa74f487e47b0c3f59316f1ca5d5c1f3) Updating devDependencies
-   [`77fc157`](https://github.com/gruntjs/grunt/commit/77fc15709548dcbb1162968ba01f79365e58d33e) Use the local version of grunt to run tests
-   [`3fcf921`](https://github.com/gruntjs/grunt/commit/3fcf921834cb3890ae05352881fa488716b374c4) Install npm@&#8203;3 if npm version is npm 1 or 2
-   [`19003ba`](https://github.com/gruntjs/grunt/commit/19003baef481f08737b21dbf4ef05f5ecade6cbc) For appveyor, check node version to decide whether to install npm@&#8203;3
-   [`6b97ac0`](https://github.com/gruntjs/grunt/commit/6b97ac0de97874802261394b98683ba92fd008aa) Try to fix appveyor script
-   [`48bba6c`](https://github.com/gruntjs/grunt/commit/48bba6cc8ca5912ec21d08f096ee07bd51666203) Move to the test script to avoid npm was unexpected at this time.
-   [`a9a20da`](https://github.com/gruntjs/grunt/commit/a9a20daba9ef845018d28d08c98c43d6f7e6ff36) Try and debug why appveyor is failing on npm
-   [`f6cbb63`](https://github.com/gruntjs/grunt/commit/f6cbb6325c2cfc7a4da6d2f0d9f395db0c29b58b) Oh right, Windows isnt bash
-   [`7c5242f`](https://github.com/gruntjs/grunt/commit/7c5242f936a851c1b0f227fd3f626ea83f3c95f2) Use node executable for local grunt bin for Windows support
-   [`06b377e`](https://github.com/gruntjs/grunt/commit/06b377e9657c3119651b11132856898a373f73e5) https links to webchat.freenode.net and gruntjs.com (#&#8203;1610)
-   [`a6a133b`](https://github.com/gruntjs/grunt/commit/a6a133b2efd72adc3e9887aea13ec9f16bbbc413) Remove deprecation warning for coffeescript (#&#8203;1621) r&#x3D;@&#8203;vladikoff
-   [`e7795dc`](https://github.com/gruntjs/grunt/commit/e7795dc2a9f904820bc909a093985e51fcf94f2b) Remove iojs from test matrix (#&#8203;1622)
-   [`ccc3163`](https://github.com/gruntjs/grunt/commit/ccc316360ba9056ccb794cc358a46cc7b8cafef9) v1.0.2

</details>