### PR TITLE
Update dependency grunt-autoprefixer to ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "^0.4.1",
-    "grunt-autoprefixer": "^0.7.3",
+    "grunt-autoprefixer": "^3.0.0",
     "grunt-concurrent": "^0.5.0",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-compass": "^0.7.2",


### PR DESCRIPTION
This Pull Request updates dependency [grunt-autoprefixer](https://github.com/ndmitry/grunt-autoprefixer) from `^0.7.3` to `^3.0.0`




<details>
<summary>Commits</summary>

#### v0.8.0
-   [`634ee3f`](https://github.com/ndmitry/grunt-autoprefixer/commit/634ee3f01d4d7d2019d6c50c475415d07fe1e78e) Update Autoprefixer dependency
-   [`c658fb7`](https://github.com/ndmitry/grunt-autoprefixer/commit/c658fb7c9eab92ee760587b478b618cc8ad8bda5) Refactor options
-   [`1b7af91`](https://github.com/ndmitry/grunt-autoprefixer/commit/1b7af9174eba31115738e764f8c40b7b9c0e3560) Update readme
-   [`b2eb059`](https://github.com/ndmitry/grunt-autoprefixer/commit/b2eb059fc8ca17da3499a126c223a6475b38e438) 0.8.0
#### v0.8.1
-   [`9c39f7b`](https://github.com/ndmitry/grunt-autoprefixer/commit/9c39f7b604c26a0e4dfa36a5c200e954f40ae275) Fix typo
-   [`39e9ebc`](https://github.com/ndmitry/grunt-autoprefixer/commit/39e9ebcc337a27669eb2f1276f6b91465b98f70b) Merge pull request #&#8203;49 from BBosman/created
-   [`39be788`](https://github.com/ndmitry/grunt-autoprefixer/commit/39be7884ed41bf9a463ca3a4c82aaefc8be0f34d) Update Autoprefixer
#### v0.8.2
-   [`a775eb3`](https://github.com/ndmitry/grunt-autoprefixer/commit/a775eb37b3bf03ae084efae61327900b4c1ba257) 0.8.1
-   [`bcb43cf`](https://github.com/ndmitry/grunt-autoprefixer/commit/bcb43cf373127f6f454768a093c6d7f259857406) Bumps chalk to 0.5.x.
-   [`bba06be`](https://github.com/ndmitry/grunt-autoprefixer/commit/bba06bebaed5251ecdb6c5fbd818a8feaf68f2ee) Merge pull request #&#8203;52 from jbnicolai/bump-chalk
-   [`3f93c69`](https://github.com/ndmitry/grunt-autoprefixer/commit/3f93c69edc679f8d3b826a62d133ac0249c53309) Bump time-grunt
-   [`36b8781`](https://github.com/ndmitry/grunt-autoprefixer/commit/36b8781faa1356b826f31ffe043ee0d3c07d8423) Use caret for Autoprefixer&#x27;s version
-   [`67dac4d`](https://github.com/ndmitry/grunt-autoprefixer/commit/67dac4d4f13d7e2a0d7c948c406d8bba3e7a1b43) Update tests to match `file` field shift
-   [`2a4a76d`](https://github.com/ndmitry/grunt-autoprefixer/commit/2a4a76d647ba8df08b4896ed8085eb73298579b5) Delete unused test files
-   [`6eddcaa`](https://github.com/ndmitry/grunt-autoprefixer/commit/6eddcaacd87d109ff6557faa42370b1b52320b0d) Clean-up
-   [`0bc87d8`](https://github.com/ndmitry/grunt-autoprefixer/commit/0bc87d88154c4ac91a67e4092f65c14122b2f74b) 0.8.2
#### v1.0.0
-   [`dd35f5f`](https://github.com/ndmitry/grunt-autoprefixer/commit/dd35f5f7acb049425c473edc4319b681f2b489d8) added &quot;silent&quot; option to suppress grunt.log.writeln
-   [`960a4fe`](https://github.com/ndmitry/grunt-autoprefixer/commit/960a4feb8ab5d09aa97c0768d23d987cbf68fe49) fixed typo and style error in readme
-   [`20b25ea`](https://github.com/ndmitry/grunt-autoprefixer/commit/20b25ea31b8adfd6b02e60ce58623c50d667b943) logging abstracted to a new function to avoid repeating
-   [`01180a2`](https://github.com/ndmitry/grunt-autoprefixer/commit/01180a241cea3f6387f9432fd3641a5487523942) Merge pull request #&#8203;55 from danyshaanan/master
-   [`72c447e`](https://github.com/ndmitry/grunt-autoprefixer/commit/72c447e8dc5f900c067a96a49ca8773aac94234b) Use .diff extension for generated diffs
-   [`173b76e`](https://github.com/ndmitry/grunt-autoprefixer/commit/173b76e8f2633c22b3d18b717c647a0cf6b9958e) Test sourcemaps by deep equality
-   [`39743db`](https://github.com/ndmitry/grunt-autoprefixer/commit/39743db32baa564d968a8d8d4328ed6eab45fb0e) Declare default `false` for the silent option
-   [`6da5d27`](https://github.com/ndmitry/grunt-autoprefixer/commit/6da5d279e5379e23a7868884730ac333fe769fd0) Don&#x27;t add final newlines in sourcemaps
-   [`4566410`](https://github.com/ndmitry/grunt-autoprefixer/commit/4566410cfdce6247cba973fe266c57d9cca97b17) Update dependencies
-   [`b492c79`](https://github.com/ndmitry/grunt-autoprefixer/commit/b492c7907c8d74c690a03e5737d1be0314239bed) Add keywords to package.json
-   [`3b1e84d`](https://github.com/ndmitry/grunt-autoprefixer/commit/3b1e84de95097a67b6b5ab088d40bb269b6f626b) Documentation improvements
-   [`4a9daaa`](https://github.com/ndmitry/grunt-autoprefixer/commit/4a9daaad70f7198517e96a24958661239b8ff060) Remove a redundant variable
-   [`9edfdd5`](https://github.com/ndmitry/grunt-autoprefixer/commit/9edfdd5ef45cf0c20804d89dcabe961f4cf703a3) Fix a typo in the readme, rephrase `silent` option description
-   [`f4fce71`](https://github.com/ndmitry/grunt-autoprefixer/commit/f4fce717f607b35521c9cdd8b1ece62bfcc1a8c8) Update a license file
-   [`d7bb2ab`](https://github.com/ndmitry/grunt-autoprefixer/commit/d7bb2ab185f2c174b1ce3105204bba966cd1e3dd) Rename nodeunit test file
-   [`d4bd32d`](https://github.com/ndmitry/grunt-autoprefixer/commit/d4bd32d01392ce7c45068799cc5be5c754f3a048) Remove `main` field from package.json
-   [`e14c128`](https://github.com/ndmitry/grunt-autoprefixer/commit/e14c1283dcf08986919f2c176f6d535c0c5ebb08) Use `files` field instead of .npmignore
-   [`475d371`](https://github.com/ndmitry/grunt-autoprefixer/commit/475d37111c32e48b58eb3a966173a64a90601560) 1.0.0
#### v1.0.1
-   [`16b138e`](https://github.com/ndmitry/grunt-autoprefixer/commit/16b138eabb842843194e22b91e18fb62bc18a2e7) Autoprefixer 3.0
-   [`fe3f905`](https://github.com/ndmitry/grunt-autoprefixer/commit/fe3f905cf5e96a01f8448044909cf96db827d64b) Update dev dependenices
-   [`c31b471`](https://github.com/ndmitry/grunt-autoprefixer/commit/c31b471dce647eca5221a421353eb6026f0bbf3b) Update links to Autoprefixer
-   [`8b63bc6`](https://github.com/ndmitry/grunt-autoprefixer/commit/8b63bc6b9ce2de94d8fcde53bbffcb58d9008fde) 1.0.1. Close #&#8203;59
#### v2.0.0
-   [`f66079f`](https://github.com/ndmitry/grunt-autoprefixer/commit/f66079f0b2c290f448489c69412980d2846f1c1a) Adding the correct wording for version
-   [`1a2689f`](https://github.com/ndmitry/grunt-autoprefixer/commit/1a2689faf521229665b5202dd9e2880f69aa4eae) Merge pull request #&#8203;62 from jamierytlewski/update-docs
-   [`bd829fe`](https://github.com/ndmitry/grunt-autoprefixer/commit/bd829fea198df769e19b652c28d2a3bffbf2173e) Correct mistake in changelog
-   [`79ad674`](https://github.com/ndmitry/grunt-autoprefixer/commit/79ad674e84208af7d382cdcca6d01af9bbef84f2) Merge pull request #&#8203;73 from htanjo/fix-changelog
-   [`e99a162`](https://github.com/ndmitry/grunt-autoprefixer/commit/e99a1622407451a3c9a0eab5778282b6bfe0575f) Autoprefixer 4.0
-   [`9ae8cae`](https://github.com/ndmitry/grunt-autoprefixer/commit/9ae8cae268deedf61e33193d347077de60e1e6de) 2.0.0
#### v2.1.0
-   [`7f6a0b4`](https://github.com/ndmitry/grunt-autoprefixer/commit/7f6a0b423d2946bddb0d5f11c06b1f58914c5963) Fix changelog
-   [`d61be5a`](https://github.com/ndmitry/grunt-autoprefixer/commit/d61be5ae414b2ff0074c291b8ca3da4d01bf688d) Support PostCSS safe mode. Merge #&#8203;78
-   [`fc5902e`](https://github.com/ndmitry/grunt-autoprefixer/commit/fc5902e8acf58185c3ff315f10f0ad838d459eb4) Update dependenices
-   [`46c8155`](https://github.com/ndmitry/grunt-autoprefixer/commit/46c815597b09ec60c10460368afb808f7774d846) 2.1.0
#### v2.2.0
-   [`1e091db`](https://github.com/ndmitry/grunt-autoprefixer/commit/1e091db861ab285b797fc6625c04ed63e519d967) Fix readme
-   [`bece729`](https://github.com/ndmitry/grunt-autoprefixer/commit/bece729035f69ff0622b0a1b7fa63bb855abe357) Autoprefixer 5.0. Close #&#8203;90
-   [`0a9f32b`](https://github.com/ndmitry/grunt-autoprefixer/commit/0a9f32ba4f20e2528b258b6011cd4a89e100373d) Fix `sourcesContent` option spelling in the readme. See #&#8203;91
-   [`e30d2c5`](https://github.com/ndmitry/grunt-autoprefixer/commit/e30d2c5bfda027e1e196a640010e05aabca329c6) 2.2.0
#### v3.0.0
-   [`c434d32`](https://github.com/ndmitry/grunt-autoprefixer/commit/c434d32b11a7f51cbe20cfdf4a939d8b773a6acb) Add node 0.12 to Travis CI
-   [`dace084`](https://github.com/ndmitry/grunt-autoprefixer/commit/dace084868d2a34ff04d7b74baed28d4412cc6ef) Update the dependencies
-   [`27c2b31`](https://github.com/ndmitry/grunt-autoprefixer/commit/27c2b3129b67996d006b7ba167902fc07718beca) Merge pull request #&#8203;100 from askmatey/master
-   [`dd8dc88`](https://github.com/ndmitry/grunt-autoprefixer/commit/dd8dc88f3a2806cb23b202f5b964748fdc807ba7) Use `grunt.verbose` instead of logging every created file.
-   [`d76d63d`](https://github.com/ndmitry/grunt-autoprefixer/commit/d76d63d1cd72803979d4ebdc7079d635438854b3) Add brackets to multiple_files in README
-   [`4ea7249`](https://github.com/ndmitry/grunt-autoprefixer/commit/4ea7249f60482c006e8720bf0315ba764d01b032) Sourcemap annotations should be string, not boolean, values
-   [`fab4da0`](https://github.com/ndmitry/grunt-autoprefixer/commit/fab4da0ceb55c456e8b840164d0a5ecf4c9f593d) Fail with catched exceptions. Close #&#8203;92 #&#8203;93
-   [`5e10787`](https://github.com/ndmitry/grunt-autoprefixer/commit/5e107878c1d0315ea36db99deffc2ec3bfcb9d7a) Merge pull request #&#8203;102 from AntoineBoulanger/master
-   [`acfcdcc`](https://github.com/ndmitry/grunt-autoprefixer/commit/acfcdcca3f754d71d9900df6a1d1909cbc60dbe4) Merge pull request #&#8203;105 from Bendihossan/fix-autoprefixer-annotation-path
-   [`9f0700f`](https://github.com/ndmitry/grunt-autoprefixer/commit/9f0700f86487296df0e8dc8782b84adcd373b5be) Merge pull request #&#8203;101 from wbinnssmith/wbinnssmith-quiet
-   [`17138bb`](https://github.com/ndmitry/grunt-autoprefixer/commit/17138bbca43d3357637ac1f2d6986abf50c6c7f3) Fix #&#8203;101
-   [`fb5cb5a`](https://github.com/ndmitry/grunt-autoprefixer/commit/fb5cb5af1d5cc74787d1b72e7286000e081cc183) Add io.js to Travic CI
-   [`6f8dfe8`](https://github.com/ndmitry/grunt-autoprefixer/commit/6f8dfe8840c48a394da478c553eb4748c4ffc79b) 3.0.0
#### v3.0.1
-   [`c1d6188`](https://github.com/ndmitry/grunt-autoprefixer/commit/c1d61880c26c1ee1b903e956ace6be1663380934) Update CHANGELOG
-   [`51eaab6`](https://github.com/ndmitry/grunt-autoprefixer/commit/51eaab6f55e3ba21cd5e12d6b08b9855200c761d) Merge pull request #&#8203;106 from alinchican/patch-1
-   [`6088b84`](https://github.com/ndmitry/grunt-autoprefixer/commit/6088b8423f7e6858e58c05aa1cc7a65f2a2e7f59) Compatibility with Autoprefixer 5.2. Close #&#8203;113
-   [`e020f87`](https://github.com/ndmitry/grunt-autoprefixer/commit/e020f878d5fe1a3f9f15bc7533b31c12ffa74799) Readme update, add depcrecation notice, close #&#8203;109
-   [`9fe7f43`](https://github.com/ndmitry/grunt-autoprefixer/commit/9fe7f43a82de03b901c926ce97d539a56f75ce4d) Comply PostCSS Runner Guidlines
#### v3.0.2
-   [`e0f378e`](https://github.com/ndmitry/grunt-autoprefixer/commit/e0f378ee6d58109f9c6ea9669d89e23b7f5b9561) Fix grunt-autoprefixer blocking grunt when it finds no files
-   [`0c67c8e`](https://github.com/ndmitry/grunt-autoprefixer/commit/0c67c8e58f2a63fa7feb42bfc2fccf24d90573a5) Fix absent source files handling
-   [`167ddc3`](https://github.com/ndmitry/grunt-autoprefixer/commit/167ddc32bf38b7d1677bfbefd9c49c25ae80ae68) Fix logging
-   [`1007a79`](https://github.com/ndmitry/grunt-autoprefixer/commit/1007a791e64fd52b913cc05e5a392de5ee94a684) 3.0.2
#### v3.0.3
-   [`08c3eb9`](https://github.com/ndmitry/grunt-autoprefixer/commit/08c3eb9dd9d7ba30e054bbc9d2ac3445b769bf50) Merge pull request #&#8203;116 from 0xR/master
-   [`b16b0bc`](https://github.com/ndmitry/grunt-autoprefixer/commit/b16b0bced03d85ad7a4c2f35f619f48d8527b544) 3.0.3
#### v3.0.4
-   [`b93c6fd`](https://github.com/ndmitry/grunt-autoprefixer/commit/b93c6fd7a3248ab6e97bcb8d8bba3cc05cea6f7e) update grunt peerDep
-   [`3dda680`](https://github.com/ndmitry/grunt-autoprefixer/commit/3dda6804cd49272e6e80f432e48decc089263a80) Merge pull request #&#8203;121 from vladikoff/patch-1
-   [`d6b6ec6`](https://github.com/ndmitry/grunt-autoprefixer/commit/d6b6ec68688fe2cc229841e1e6f3e76a5adebe94) 3.0.4

</details>