### PR TITLE
Update dependency grunt-concurrent to ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "grunt": "^0.4.1",
     "grunt-autoprefixer": "^0.7.3",
-    "grunt-concurrent": "^0.5.0",
+    "grunt-concurrent": "^2.0.0",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-compass": "^0.7.2",
     "grunt-contrib-concat": "^0.4.0",


### PR DESCRIPTION
This Pull Request updates dependency [grunt-concurrent](https://github.com/sindresorhus/grunt-concurrent) from `^0.5.0` to `^2.0.0`




<details>
<summary>Commits</summary>

#### v1.0.0
-   [`a314bcf`](https://github.com/sindresorhus/grunt-concurrent/commit/a314bcfc749b500c957db4ee80288407b4670258) fix travis
-   [`5423e26`](https://github.com/sindresorhus/grunt-concurrent/commit/5423e260c6cd0bee549b4185eba6d6734d3dd160) Update readme.md
-   [`690de25`](https://github.com/sindresorhus/grunt-concurrent/commit/690de25928a4634477aa9ea2435413676b69bde9) tweaks
#### v1.0.1
-   [`dc1f8fb`](https://github.com/sindresorhus/grunt-concurrent/commit/dc1f8fbde1b22ac69fcf0734c357f6729f004710) increase the default concurrency to twice the amount of cpu cores
-   [`1b9ce3a`](https://github.com/sindresorhus/grunt-concurrent/commit/1b9ce3aecba864b2136550f0d5f8b76e7b51f3bb) 1.0.0
-   [`350f2bd`](https://github.com/sindresorhus/grunt-concurrent/commit/350f2bd5097f3558b83ceb90a22f8fa8422797df) fix travis
-   [`06c16de`](https://github.com/sindresorhus/grunt-concurrent/commit/06c16de5a98d88ffae946170cea6dee942ce7d90) Update doc to make it clearer
-   [`450cc72`](https://github.com/sindresorhus/grunt-concurrent/commit/450cc72419dcd02bed2e72e614b5d3bdb46b2303) Merge pull request #&#8203;49 from kerryChen95/master
-   [`70e9602`](https://github.com/sindresorhus/grunt-concurrent/commit/70e96022f9206ef1b9e990ee75cd116b00735a1b) Update .travis.yml
-   [`129411b`](https://github.com/sindresorhus/grunt-concurrent/commit/129411b6c14b030a1641dbb9ad55db561ea1c4fb) Close #&#8203;52 PR: disabling inheriting of process.stdin as it would trump ownership of std....
-   [`fd89286`](https://github.com/sindresorhus/grunt-concurrent/commit/fd892866bdcc721e7ce64415e59a19f27e6f4373) 1.0.1
#### v2.0.0
-   [`9390063`](https://github.com/sindresorhus/grunt-concurrent/commit/9390063bf31ddcf4f397a92b3cda61a94808fa21) force kill all child processes
-   [`5ded345`](https://github.com/sindresorhus/grunt-concurrent/commit/5ded34533a471d036235c9c9be53232e5d033115) output stderr too and improve error handling - fixes #&#8203;57
-   [`317cc79`](https://github.com/sindresorhus/grunt-concurrent/commit/317cc79629db416f30a17780226aabbc0c4af1f8) bump deps
-   [`37e08ba`](https://github.com/sindresorhus/grunt-concurrent/commit/37e08ba0a2c6f71de26142d34dd6ef945c3c8a4c) minor tweaks
-   [`1d8d120`](https://github.com/sindresorhus/grunt-concurrent/commit/1d8d1202d5a812045cd52618d8f8384deeb598ec) Close #&#8203;59 PR: pad the output in `logConcurrentOutput` mode. Fixes #&#8203;43, Fixes #&#8203;55
-   [`07dd63b`](https://github.com/sindresorhus/grunt-concurrent/commit/07dd63bf3e24e35397b75cf5c2d9faaabda57ebd) 2.0.0
#### v2.0.1
-   [`54a87d4`](https://github.com/sindresorhus/grunt-concurrent/commit/54a87d4313ce481757fa92d3b7d56dcecf16d77c) use `path-exists` module as `fs.exists` is being deprecated
-   [`626d0ac`](https://github.com/sindresorhus/grunt-concurrent/commit/626d0ac4e55e2125f498f107b9a472c25a942a11) Swap pad-stdio dep for pad-stream
-   [`e7956ef`](https://github.com/sindresorhus/grunt-concurrent/commit/e7956ef8dd255f57d17000804448b3c98ea3bd14) Merge pull request #&#8203;69 from jimf/fix-newline-padding
-   [`cc7fee9`](https://github.com/sindresorhus/grunt-concurrent/commit/cc7fee996a6bd2f8ae8b7f68b0b51fbd3163d59f) indent non-concurrent logging too - followup to #&#8203;69
-   [`2dfa96c`](https://github.com/sindresorhus/grunt-concurrent/commit/2dfa96cd1b2196be037ca7af86d487549e48d899) 2.0.1
#### v2.0.2
-   [`a970e09`](https://github.com/sindresorhus/grunt-concurrent/commit/a970e095bb398afcf00102fe21b74e8705c4c512) Clean up child processes on SIGINT (CTRL-C)
-   [`f2ebf94`](https://github.com/sindresorhus/grunt-concurrent/commit/f2ebf94193a87021024349295e0482555c4a97b3) Merge pull request #&#8203;73 from ekashida/handle-sigint
-   [`0bcb7b3`](https://github.com/sindresorhus/grunt-concurrent/commit/0bcb7b314a14641086d1ee0b89379a880bee6746) add XO
-   [`3ac0193`](https://github.com/sindresorhus/grunt-concurrent/commit/3ac01933d916dc319c042cbd85dc39e22bd891da) 2.0.2
#### v2.0.3
-   [`cc483a9`](https://github.com/sindresorhus/grunt-concurrent/commit/cc483a9ff3f1e52f427f052436f8ab4542d7227e) correctly handle SIGINT - fixes #&#8203;74
-   [`ec408c8`](https://github.com/sindresorhus/grunt-concurrent/commit/ec408c8712c0fff2febc346a84175d6a8a2c587b) 2.0.3
#### v2.0.4
-   [`9d350a9`](https://github.com/sindresorhus/grunt-concurrent/commit/9d350a9c6ff5a4104348a2137b04888764e04e58) Close #&#8203;79 PR: Use cross-spawn in tests so that they won&#x27;t fail on Windows..
-   [`675cb92`](https://github.com/sindresorhus/grunt-concurrent/commit/675cb92c27b1f405ad6f730ceffb3d3f7152d487) Close #&#8203;80 PR: Fix concurrent output logs not being colorized. Fixes #&#8203;70
-   [`d897487`](https://github.com/sindresorhus/grunt-concurrent/commit/d89748759c2c80d9a280e247a3fdd1d48ccb00fa) 2.0.4
#### v2.1.0
-   [`1a2cb91`](https://github.com/sindresorhus/grunt-concurrent/commit/1a2cb915569320a90fc344dc0d4b7241e3547b85) bump dev deps
-   [`3f51264`](https://github.com/sindresorhus/grunt-concurrent/commit/3f5126494a5bb6298ea3749b081853d29225211b) 2.1.0
#### v2.2.0
-   [`00450a3`](https://github.com/sindresorhus/grunt-concurrent/commit/00450a34ae6e07f73c9a0b21a27b81fd685374ea) Close #&#8203;83 PR: Allow task to be in fact an array of tasks.
-   [`489c56d`](https://github.com/sindresorhus/grunt-concurrent/commit/489c56d0ed412984171bcea77e2ac970774aae7e) 2.2.0
#### v2.2.1
-   [`db59e35`](https://github.com/sindresorhus/grunt-concurrent/commit/db59e357f31a77c9dc22e3763ab9f0a0e81c84cc) minor tweaks
-   [`8affd01`](https://github.com/sindresorhus/grunt-concurrent/commit/8affd0114cf2ddb6167dc140e5c2a9ce2aa9d4c2) fix dependencies
-   [`d239765`](https://github.com/sindresorhus/grunt-concurrent/commit/d2397659fd5822f55ecb0ca3d4eb434d499a2aff) 2.2.1
#### v2.3.0
-   [`47f809e`](https://github.com/sindresorhus/grunt-concurrent/commit/47f809ed3c3e3a06d86c5f1f475a0b237d8f826f) meta tweaks
#### v2.3.1
-   [`62e5c9d`](https://github.com/sindresorhus/grunt-concurrent/commit/62e5c9d0ac18ce2cdc42f7fd9ee5909f5f859167) 2.3.0
-   [`4f9de30`](https://github.com/sindresorhus/grunt-concurrent/commit/4f9de3093e473fd02991c65825fc73bad07d7947) trying out something new
-   [`0d76521`](https://github.com/sindresorhus/grunt-concurrent/commit/0d76521f09919e97704c45868dc1e86ce1352537) 2.3.1

</details>