### PR TITLE
Update dependency grunt-contrib-compass to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "grunt-autoprefixer": "^0.7.3",
     "grunt-concurrent": "^0.5.0",
     "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-compass": "^0.7.2",
+    "grunt-contrib-compass": "^1.0.0",
     "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-connect": "^0.7.1",
     "grunt-contrib-copy": "^0.5.0",


### PR DESCRIPTION
This Pull Request updates dependency [grunt-contrib-compass](https://github.com/gruntjs/grunt-contrib-compass) from `^0.7.2` to `^1.0.0`




<details>
<summary>Commits</summary>

#### v0.8.0
-   [`c40ed21`](https://github.com/gruntjs/grunt-contrib-compass/commit/c40ed21a982c0e2c3beb13ff25eb072e3d103b9e) update changelog
-   [`b9cf04d`](https://github.com/gruntjs/grunt-contrib-compass/commit/b9cf04db87cc05fb044878a61325c9d72cad7612) Update copyright to 2014
-   [`777b5a0`](https://github.com/gruntjs/grunt-contrib-compass/commit/777b5a038d20d9dfca0577e4788f60e8420a77cc) Update README.md
-   [`f4155ee`](https://github.com/gruntjs/grunt-contrib-compass/commit/f4155eeac170abe8a8e052ac7b1a43fc22d0afa9) Merge pull request #&#8203;151 from shairez/patch-1
-   [`5943bda`](https://github.com/gruntjs/grunt-contrib-compass/commit/5943bda134e8d1fb7f2d65404fa2beb2860482b1) Update compass-options.md
-   [`72b5a8a`](https://github.com/gruntjs/grunt-contrib-compass/commit/72b5a8a84920880d0e9666beebc96cf253a796c8) Add spriteLoadPath as option for compass
-   [`ce485e3`](https://github.com/gruntjs/grunt-contrib-compass/commit/ce485e3140adcae1adf013dc0ba8722775d0e7e1) fix tests
#### v0.9.0
-   [`79eb6ff`](https://github.com/gruntjs/grunt-contrib-compass/commit/79eb6ff0b7b046de3b15bdce119d937bb145f1c2) release prep
-   [`e2b04fc`](https://github.com/gruntjs/grunt-contrib-compass/commit/e2b04fc107b0c525198da62199a18afb764501cf) 0.8.0
-   [`7466c56`](https://github.com/gruntjs/grunt-contrib-compass/commit/7466c56232aad62ba959e7c1047e4a4dc491a065) add compass version check - fixes #&#8203;143
-   [`cf23e95`](https://github.com/gruntjs/grunt-contrib-compass/commit/cf23e9572c3ebcc46d9a75e00f650a2104b6b0bb) changelog
#### v0.9.1
-   [`d285b98`](https://github.com/gruntjs/grunt-contrib-compass/commit/d285b98ce26057467269c107b1d91de91ede1343) 0.9.0
-   [`9af0cc3`](https://github.com/gruntjs/grunt-contrib-compass/commit/9af0cc31c0f49195f12cd68e07a10d5c66529569) apparently i can&#x27;t time travel...
-   [`51acc9c`](https://github.com/gruntjs/grunt-contrib-compass/commit/51acc9c890fd30d82a9c46a98112fa1648e71772) Gracefully cleanup tmp config files when non-cli options are specified.
-   [`d078a42`](https://github.com/gruntjs/grunt-contrib-compass/commit/d078a420a299d14bccb67434d0e225f56aa4c5fb) Merge pull request #&#8203;175 from ryan953/gracefully-cleanup-tmp-files
#### v1.0.0
-   [`13a164d`](https://github.com/gruntjs/grunt-contrib-compass/commit/13a164de2b6e8822c7fabe62238f2bb02cf1ef57) v0.9.1 Fixes #&#8203;186
-   [`20e27d3`](https://github.com/gruntjs/grunt-contrib-compass/commit/20e27d33cc194a19fce0a5afdbdea53df5d87c79) Fix for issue #&#8203;176, bundleExec on Win32
-   [`f214ab1`](https://github.com/gruntjs/grunt-contrib-compass/commit/f214ab10bbfba4f19cae303d7e86d6ed37c4a825) Merge pull request #&#8203;189 from Jusas/master
-   [`19e13cb`](https://github.com/gruntjs/grunt-contrib-compass/commit/19e13cb0e385e151ce2f0ccb399e3158770b432d) First check code with jshint upon running npm/grunt test
-   [`1574b17`](https://github.com/gruntjs/grunt-contrib-compass/commit/1574b175abdb2a7c107676b9a673dd21531b6aa6) Merge pull request #&#8203;192 from radkodinev/run-jshint-with-tests
-   [`f59e830`](https://github.com/gruntjs/grunt-contrib-compass/commit/f59e830865221af0a8c8e2dae9f2d84e77567a88) bump deps
-   [`e15bce0`](https://github.com/gruntjs/grunt-contrib-compass/commit/e15bce0114e222cb3223c3a0e55fa467480fdbee) update changelog
#### v1.0.1
-   [`ce7f01b`](https://github.com/gruntjs/grunt-contrib-compass/commit/ce7f01b88b67b562dcb8017d0f2bb024051a6f07) 1.0.0
-   [`adc77b7`](https://github.com/gruntjs/grunt-contrib-compass/commit/adc77b7ae5ca88d9dc36846b4b792c973b751dee) Use compass long flag for import-path
-   [`05aa8b5`](https://github.com/gruntjs/grunt-contrib-compass/commit/05aa8b584502767665b59d3ac01d95acc041ab55) Merge pull request #&#8203;196 from thisischrisj/master
#### v1.0.2
-   [`1d887e3`](https://github.com/gruntjs/grunt-contrib-compass/commit/1d887e343853bc46db6d187b91c4361f1a318ffb) update changelog
-   [`fdf4b6f`](https://github.com/gruntjs/grunt-contrib-compass/commit/fdf4b6fc1d5fa9b3ce2ac6f1f2fe9d34e1a101ca) 1.0.1
-   [`ca8968b`](https://github.com/gruntjs/grunt-contrib-compass/commit/ca8968b12a47e446f3be3421b6e593a596bdddfe) fix travis
-   [`9ebc5f1`](https://github.com/gruntjs/grunt-contrib-compass/commit/9ebc5f19186094c081630dadcee292eba059e322) Update README.md
-   [`9ef973c`](https://github.com/gruntjs/grunt-contrib-compass/commit/9ef973c081e5947bff250b806037e39532a08c15) Merge pull request #&#8203;205 from jefflembeck/master
-   [`c43411a`](https://github.com/gruntjs/grunt-contrib-compass/commit/c43411a1ee120266a41a617829d0226f5eb8e7ac) bump deps
-   [`e99d6ac`](https://github.com/gruntjs/grunt-contrib-compass/commit/e99d6ac560f0445a95675255f833aeb4f3ae1b3d) update compass version requirement
-   [`01e0dc3`](https://github.com/gruntjs/grunt-contrib-compass/commit/01e0dc3f5347a4a1708e3e9a61c4971275e2f042) document sourcemap option
-   [`4d08b3a`](https://github.com/gruntjs/grunt-contrib-compass/commit/4d08b3a3e9edf5000ac8df32445a4d31cc6ae8fd) remove `dryRun` option from docs - fixes #&#8203;206
-   [`1c9dc8f`](https://github.com/gruntjs/grunt-contrib-compass/commit/1c9dc8f1738ed5d11f2a55b202b62151f341bd67) Fix link to Compass configuration reference
-   [`f929069`](https://github.com/gruntjs/grunt-contrib-compass/commit/f9290693aa4a9c8f8dc50a995b37041136f6b1a8) Merge pull request #&#8203;208 from fhemberger/patch-1
-   [`d3d3f45`](https://github.com/gruntjs/grunt-contrib-compass/commit/d3d3f4528dab5c38bcba4755209a93070702ab80) readme tweaks
-   [`7820da6`](https://github.com/gruntjs/grunt-contrib-compass/commit/7820da6de199b28533f0c8c8d6e0745daeca7bfe) Update copyright to 2015
-   [`fa56ce3`](https://github.com/gruntjs/grunt-contrib-compass/commit/fa56ce3b107ea2062d70d3d84dcbb4537cc76b3e) minor tweaks
-   [`ead046e`](https://github.com/gruntjs/grunt-contrib-compass/commit/ead046ebb4fae7f7062f80617cf8573cbf296797) Close #&#8203;224 PR: Posixly correct.
-   [`69e0587`](https://github.com/gruntjs/grunt-contrib-compass/commit/69e05879e6a0d6fea215f21532ea7869becde155) changelog
-   [`a736fed`](https://github.com/gruntjs/grunt-contrib-compass/commit/a736fed14f0e419bd54408f5143686f12f6562cd) 1.0.2
#### v1.0.3
-   [`f0a3922`](https://github.com/gruntjs/grunt-contrib-compass/commit/f0a3922000912202ca2cad71d640842c625597ac) Close #&#8203;233 PR: Fix #&#8203;232: add --config path before `--` option/argument separator. Fixes #&#8203;232
-   [`6fe120f`](https://github.com/gruntjs/grunt-contrib-compass/commit/6fe120f91d64f3324a667e14fa16c70e28b16048) bump readme
-   [`0c31fd8`](https://github.com/gruntjs/grunt-contrib-compass/commit/0c31fd8eb03673133a944b1c51a4581f57381b66) 1.0.3
#### v1.0.4
-   [`d0d0dcf`](https://github.com/gruntjs/grunt-contrib-compass/commit/d0d0dcf44ee2bc8d192b7763102ff9a2d297b59d) feat(autoselect): Finds the first instance of compass and bundle in the PATH environment variable
-   [`62f7663`](https://github.com/gruntjs/grunt-contrib-compass/commit/62f766321a318eb639f9e47589611d168d9060eb) Insert only basename
-   [`2eec6b8`](https://github.com/gruntjs/grunt-contrib-compass/commit/2eec6b81ed093bd607c7e795e2d70dcc0de1d3be) Fix deprecated package.json licenses
-   [`ad264b8`](https://github.com/gruntjs/grunt-contrib-compass/commit/ad264b880ee0ea007ab1334fbb11d5b4b829dd61) Add v1.0.3 to Changelog
-   [`852a4b5`](https://github.com/gruntjs/grunt-contrib-compass/commit/852a4b532ae65d9cf08a7c65be09c9e57dff5ae4) Merge pull request #&#8203;241 from tedyoung/patch-1
-   [`4db451a`](https://github.com/gruntjs/grunt-contrib-compass/commit/4db451ad3442264d6d8398429722994d622329d0) use the Compass CLI flag for the `httpPath` option - fixes #&#8203;190
-   [`f9cf06e`](https://github.com/gruntjs/grunt-contrib-compass/commit/f9cf06ef84fe48ac776d18d3b51ca20d5a43f02a) Close #&#8203;244 PR: Fix #&#8203;219: add single quotes to the config.rb generated file.
-   [`4e6ba15`](https://github.com/gruntjs/grunt-contrib-compass/commit/4e6ba157aa5f825c5700fdebbb4e918fb6abb8e6) changelog
-   [`a306002`](https://github.com/gruntjs/grunt-contrib-compass/commit/a30600243f12981749b939fea6732a2623c7a87b) 1.0.4
#### v1.1.0
-   [`718d021`](https://github.com/gruntjs/grunt-contrib-compass/commit/718d0210c4c24485e1966c39fc6fb575545b80ee) Add node.js 4 in Travis CI.
-   [`1eab4f2`](https://github.com/gruntjs/grunt-contrib-compass/commit/1eab4f247829771fa19ad1f83de9e6306581b80e) Update JSHint&#x27;s options.
-   [`ba69a49`](https://github.com/gruntjs/grunt-contrib-compass/commit/ba69a49419034332bbca228ae32e5a9b4f4e7ba7) Update .gitignore.
-   [`7a3ecad`](https://github.com/gruntjs/grunt-contrib-compass/commit/7a3ecad65699357cd6282f51071fbe7b1a3c81d4) Lint all JS files.
-   [`88005c5`](https://github.com/gruntjs/grunt-contrib-compass/commit/88005c5c9ef2241a1dc33c4a8eb2ac7dadbaffc3) Update docs.
-   [`a40fa22`](https://github.com/gruntjs/grunt-contrib-compass/commit/a40fa22cce941cf1f4eeb83b0ac4d6e7ed61bcc3) CI: Remove node.js &#x27;0.12&#x27; and add &#x27;5&#x27;.
-   [`afaca59`](https://github.com/gruntjs/grunt-contrib-compass/commit/afaca59ef36dab78381cd743d20edeb5331d98b4) Update copyright to 2016
-   [`1ca336e`](https://github.com/gruntjs/grunt-contrib-compass/commit/1ca336e3fc23ad2774937fbe10199c52866a1c7b) Remove peerDeps. Ref gruntjs/grunt#&#8203;1116
-   [`07e8c1a`](https://github.com/gruntjs/grunt-contrib-compass/commit/07e8c1acf4664e6bd729e0ce88011dd27af0ffdc) Point main to task
-   [`4b446f9`](https://github.com/gruntjs/grunt-contrib-compass/commit/4b446f90fd86dc23b1d3c12f1b605d7937289ad9) Add grunt as &gt;&#x3D; 0.4.5 peerDep
-   [`014a58a`](https://github.com/gruntjs/grunt-contrib-compass/commit/014a58a1889f911344ab77660fc072fc478dc86e) Update async and tmp deps
-   [`a216318`](https://github.com/gruntjs/grunt-contrib-compass/commit/a2163182454a1534f2c59d4f5a27437e20c3f39c) Updating travis and adding appveyor
-   [`d6a4e22`](https://github.com/gruntjs/grunt-contrib-compass/commit/d6a4e227729c8a470b87d270dbc8833ab0126729) Merge remote-tracking branch &#x27;malys/feature/autoselect_exe&#x27;
-   [`d2c289c`](https://github.com/gruntjs/grunt-contrib-compass/commit/d2c289c5189475ad2dc94e0ae509a5dbf6e5b5ec) Skip the posixlyCorrect task on Windows
-   [`ea72ac9`](https://github.com/gruntjs/grunt-contrib-compass/commit/ea72ac95ecae4b5140a30ed2221eb5127fe8b2a0) Fix Windows issues in the tests
-   [`300e8cc`](https://github.com/gruntjs/grunt-contrib-compass/commit/300e8cc0b2a73daae3925256e0a6564623971ec3) Clean the tmp6 folder
-   [`8e17e75`](https://github.com/gruntjs/grunt-contrib-compass/commit/8e17e75e4242a688cef594ac3e173394a1139104) v1.1.0
#### v1.1.1
-   [`da1cbcb`](https://github.com/gruntjs/grunt-contrib-compass/commit/da1cbcb990753892fb11a2ea8c0a254bd6e0d4ef) fix(bundleExec): pass only compass package name, not full path
-   [`f0b3dee`](https://github.com/gruntjs/grunt-contrib-compass/commit/f0b3deebd44ca740fe978de945e7f583fac0bdcc) Merge pull request #&#8203;250 from shahata/master
-   [`96c5bde`](https://github.com/gruntjs/grunt-contrib-compass/commit/96c5bde887b46f98091398c7a84e39c1e92fc12d) v1.1.1

</details>