### PR TITLE
Update dependency time-grunt to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "karma-jasmine": "^0.3.0",
     "karma-phantomjs-launcher": "^0.1.4",
     "load-grunt-tasks": "^0.4.0",
-    "time-grunt": "^0.3.1"
+    "time-grunt": "^1.0.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
This Pull Request updates dependency [time-grunt](https://github.com/sindresorhus/time-grunt) from `^0.3.1` to `^1.0.0`




<details>
<summary>Commits</summary>

#### v0.4.0
-   [`cc2e575`](https://github.com/sindresorhus/time-grunt/commit/cc2e5756eb0f522e657e249488380c5546a59416) Close GH-44: Allow `--verbose` and `-v` as options that display the graphs..
-   [`1dd003d`](https://github.com/sindresorhus/time-grunt/commit/1dd003d1373b66414ae7b63b1c347ef26c89922f) 0.3.2
-   [`e532c4e`](https://github.com/sindresorhus/time-grunt/commit/e532c4e056b6d90a0a5a9e1b9dfe9b8a2935422e) semicolon
-   [`c23982b`](https://github.com/sindresorhus/time-grunt/commit/c23982bd9c1744a10d2ee9b057d1a39d4d2b078d) bump deps and use figures module
#### v1.0.0
-   [`edafe53`](https://github.com/sindresorhus/time-grunt/commit/edafe534224b31a275f7e25cd96f9f59cccf20b6) use a different color on the total
-   [`18a51a2`](https://github.com/sindresorhus/time-grunt/commit/18a51a2f87af2fe7bf67e6c2b1d46d9938ad5aaf) 0.4.0
-   [`28abf0c`](https://github.com/sindresorhus/time-grunt/commit/28abf0cc5d7f649f26ba08e93e28cf15b73ef97a) tweaks
#### v1.1.0
-   [`6ec1ab3`](https://github.com/sindresorhus/time-grunt/commit/6ec1ab363b48055d393b337d0a6903c81e700992) 1.0.0
-   [`c74e31d`](https://github.com/sindresorhus/time-grunt/commit/c74e31d3ca7b81f630e53006821c68e7d0feed46) Update .travis.yml
-   [`e4bb026`](https://github.com/sindresorhus/time-grunt/commit/e4bb026503bb185dccadbb64076cd295558c218c) add support of artificial &#x27;quiet&#x27; option provided by &#x27;quiet-grunt&#x27;
-   [`efd2e0c`](https://github.com/sindresorhus/time-grunt/commit/efd2e0c38eecbdc52bf3349413d73d37dc1014fb) Merge pull request #&#8203;56 from ZuBB/patch-1
-   [`5db9ab8`](https://github.com/sindresorhus/time-grunt/commit/5db9ab87def4253f34db6a008767515cf6c531aa) mention why the `--quiet` check is there
-   [`3657891`](https://github.com/sindresorhus/time-grunt/commit/3657891a0783125272d462428bb8a3f823bb38ae) bump `chalk`
-   [`959f519`](https://github.com/sindresorhus/time-grunt/commit/959f519fbf2c81edfd776a604ac53b9319d07482) 1.1.0
#### v1.1.1
-   [`0f82be1`](https://github.com/sindresorhus/time-grunt/commit/0f82be174c7879adb0d6a854400ab2845ce27cb8) Divide by zero error if totalTime &#x3D;&#x3D; 0
-   [`28095b8`](https://github.com/sindresorhus/time-grunt/commit/28095b89aa6be98e4098c25fc2552f48b785a5e4) Merge pull request #&#8203;59 from spbolton/master
-   [`26630ce`](https://github.com/sindresorhus/time-grunt/commit/26630cef1579e710157da04a05e9bcd0c12c0249) 1.1.1
#### v1.2.0
-   [`3064bc7`](https://github.com/sindresorhus/time-grunt/commit/3064bc74889e54893d49e650c4ae21f3796d2dfe) add support for optional callback
-   [`1eacfbf`](https://github.com/sindresorhus/time-grunt/commit/1eacfbfe7ba3bd808f7b1f73a74151e6af2ba2b8) Merge pull request #&#8203;61 from geddski/master
-   [`c5d5428`](https://github.com/sindresorhus/time-grunt/commit/c5d5428febcf5641e118384a1ff5497d55b6c4f4) Various tweaks
-   [`1eda651`](https://github.com/sindresorhus/time-grunt/commit/1eda65103acc72cfdedbba98aeea399e73f65a55) minor tweaks
-   [`35f03b1`](https://github.com/sindresorhus/time-grunt/commit/35f03b192b7b08a64fe02349473210aa91b1fc5d) 1.2.0
#### v1.2.1
-   [`f82682e`](https://github.com/sindresorhus/time-grunt/commit/f82682eb102e44b87f3e742c354706c77a324199) use `Number.isNaN()` ponyfill
-   [`d4123c9`](https://github.com/sindresorhus/time-grunt/commit/d4123c957eb260ba95e320627b3ef3c3590b5bb9) 1.2.1
#### v1.2.2
-   [`efbee3a`](https://github.com/sindresorhus/time-grunt/commit/efbee3a2d23f989f3cc52dd0c8bb8f11f4c0e71e) Bumping pretty-ms to 2.x
-   [`b42b4e7`](https://github.com/sindresorhus/time-grunt/commit/b42b4e7a1378ea3d86e48f602a20d79c5ee2ad01) Merge pull request #&#8203;70 from dominykas/patch-1
-   [`e16bf95`](https://github.com/sindresorhus/time-grunt/commit/e16bf9553197898128fdd739db31c4f62c6b6dcd) 1.2.2
#### v1.3.0
-   [`e5b74e5`](https://github.com/sindresorhus/time-grunt/commit/e5b74e5444a78f7f788214c586b65875c115eb78) Close #&#8203;73 PR: Ignore watch task. Fixes #&#8203;51.
-   [`1472581`](https://github.com/sindresorhus/time-grunt/commit/14725814cc41e8b1684ea0566d54270520e0f291) minor tweaks
-   [`db11c16`](https://github.com/sindresorhus/time-grunt/commit/db11c1678e3ddcf47ec66970062d87cb9282e2a8) 1.3.0
#### v1.4.0
-   [`93a1d44`](https://github.com/sindresorhus/time-grunt/commit/93a1d4487959e1b7966d9eeceb40d644f2292546) Travis CI: Test on Node.js v4.x.x and v5.x.x
-   [`2029b20`](https://github.com/sindresorhus/time-grunt/commit/2029b2060d9b0032f220668dda4a858543cd1bda) Merge pull request #&#8203;75 from ntwb/patch-1
-   [`d72863e`](https://github.com/sindresorhus/time-grunt/commit/d72863e47f4d96a59e096cdeb672def82e6b828a) meta tweaks
-   [`cbbabe0`](https://github.com/sindresorhus/time-grunt/commit/cbbabe09762c36756495745d048800ae82d0f9ae) Merge pull request #&#8203;79 from sindresorhus/adrianlee44/fix-negative
-   [`3ee8b23`](https://github.com/sindresorhus/time-grunt/commit/3ee8b239132c8fb2a8df21c0d0aad8aff277f9ab) Update .travis.yml
-   [`3c67154`](https://github.com/sindresorhus/time-grunt/commit/3c67154581e5c681d84724a2bd8c584e07329c62) Override xo/no-process-exit
-   [`9f42505`](https://github.com/sindresorhus/time-grunt/commit/9f4250519ad7a75d9147a694910ecb0194191ea0) display local time instead of UTC time (#&#8203;83)
-   [`ce3b96f`](https://github.com/sindresorhus/time-grunt/commit/ce3b96fdaf2a44459fffd8b50c231a694c4f3fab) update screenshot
-   [`29dc47d`](https://github.com/sindresorhus/time-grunt/commit/29dc47d8e5fd3074b5867fad48f1d644afb480ae) 1.4.0

</details>